### PR TITLE
azs - update example inputs to replace deprecated DL labels

### DIFF
--- a/Examples/pbdl-0001/src/input.json
+++ b/Examples/pbdl-0001/src/input.json
@@ -87,7 +87,7 @@
             "SampleSize": "5000"
         },
         "Losses": {
-            "BldgRepair": {
+            "Repair": {
                 "ConsequenceDatabase": "FEMA P-58",
                 "DecisionVariables": {
                     "Carbon": true,
@@ -142,7 +142,7 @@
                 "JSON": false
             },
             "Loss": {
-                "BldgRepair": {
+                "Repair": {
                     "AggregateSample": true,
                     "AggregateStatistics": true,
                     "GroupedSample": true,

--- a/Examples/pbdl-0002/src/input.json
+++ b/Examples/pbdl-0002/src/input.json
@@ -63,7 +63,7 @@
             "SampleSize": "500"
         },
         "Losses": {
-            "BldgRepair": {
+            "Repair": {
                 "ConsequenceDatabase": "Hazus Earthquake - Buildings",
                 "DecisionVariables": {
                     "Carbon": false,
@@ -94,7 +94,7 @@
                 "JSON": false
             },
             "Loss": {
-                "BldgRepair": {
+                "Repair": {
                     "AggregateSample": true,
                     "AggregateStatistics": true,
                     "GroupedSample": true,

--- a/Examples/pbdl-0003/src/input.json
+++ b/Examples/pbdl-0003/src/input.json
@@ -25,6 +25,12 @@
             "ApplicationData": {
             }
         },
+        "Performance": {
+            "Application": "REDi",
+            "ApplicationData": {
+                "riskParametersPath": "{Current_Dir}/risk_params.json"
+            }
+        },
         "Simulation": {
             "Application": "OpenSees-Simulation",
             "ApplicationData": {
@@ -33,12 +39,6 @@
         "UQ": {
             "Application": "Dakota-UQ",
             "ApplicationData": {
-            }
-        },
-        "Performance" : {
-            "Application": "REDi",
-            "ApplicationData": {
-                "riskParametersPath" : "{Current_Dir}/risk_params.json"
             }
         }
     },
@@ -86,7 +86,7 @@
             "SampleSize": "500"
         },
         "Losses": {
-            "BldgRepair": {
+            "Repair": {
                 "ConsequenceDatabase": "FEMA P-58",
                 "DecisionVariables": {
                     "Carbon": true,
@@ -141,7 +141,7 @@
                 "JSON": true
             },
             "Loss": {
-                "BldgRepair": {
+                "Repair": {
                     "AggregateSample": true,
                     "AggregateStatistics": true,
                     "GroupedSample": true,


### PR DESCRIPTION
The old ones still work when run through PBE because the app fixes them but they break when the example is run directly through the backend.